### PR TITLE
Revert "🐞fix: 메소드 오버로딩을 사용하지 않도록 변경"

### DIFF
--- a/src/main/java/com/member/homework/dto/response/ApiResponse.java
+++ b/src/main/java/com/member/homework/dto/response/ApiResponse.java
@@ -20,12 +20,17 @@ public class ApiResponse<T> {
         this.data = data;
     }
 
+
     public static <T> ApiResponse<T> of(HttpStatus httpStatus, String message, T data) {
         return new ApiResponse<>(httpStatus, message, data);
     }
 
+    public static <T> ApiResponse<T> of(HttpStatus httpStatus, T data) {
+        return of(httpStatus, httpStatus.name(), data);
+    }
+
     public static <T> ApiResponse<T> ok(T data) {
-        return of(HttpStatus.OK, HttpStatus.OK.name(), data);
+        return of(HttpStatus.OK, data);
     }
 
 }


### PR DESCRIPTION
ApiResponse.of 는 파라미터를 2개만 받도록 되어있습니다. 

```java
@Getter
public class ApiResponse<T> {

    private final int code;
    private final HttpStatus status;
    private final T data;
    private final String message;

    @Builder
    private ApiResponse(HttpStatus status, String message, T data) {
        this.code = status.value();
        this.status = status;
        this.message = message;
        this.data = data;
    }

    public static <T> ApiResponse<T> of(HttpStatus httpStatus, String message, T data) {
        return new ApiResponse<>(httpStatus, message, data);
    }

    public static <T> ApiResponse<T> ok(T data) {
        return of(HttpStatus.OK, HttpStatus.OK.name(), data);
    }

}
```

혹시 본인 코드에서 확인이 되었을까요?